### PR TITLE
Check for value in applicationpackage before deploying

### DIFF
--- a/zoo-project/zoo-services/utils/open-api/dru/DeployProcess.py
+++ b/zoo-project/zoo-services/utils/open-api/dru/DeployProcess.py
@@ -286,7 +286,7 @@ def duplicateMessage(conf,deploy_process):
 
 def DeployProcess(conf, inputs, outputs):
     try:
-        if "applicationPackage" in inputs.keys() and "isArray" in inputs["applicationPackage"].keys() and inputs["applicationPackage"]["isArray"]=="true":
+        if "applicationPackage" in inputs.keys() and "isArray" in inputs["applicationPackage"].keys() and inputs["applicationPackage"]["isArray"]=="true" and "value" in inputs["applicationPackage"]:
             for i in range(int(inputs["applicationPackage"]["length"])):
                 lInputs = {"applicationPackage": {"value": inputs["applicationPackage"]["value"][i]}}
                 lInputs["applicationPackage"]["mimeType"] = inputs["applicationPackage"]["mimeType"][i]


### PR DESCRIPTION
## Bugfix
Add line to check for `value` in dictionary before attempting to access it.
This causes issue when a process is deleted and then redeployed, as it relies on a cached file, rather than the data in the `values` object.