### PR TITLE
Update pycalrissian code to be eodhp-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ docker-compose up
 ````
 
 Then, from your favorite browser, just load the following URL: http://localhost/ and get immediate access to the 700+ ZOO-Services through WPS and OGC API - Processes depending on your preferences 🎉.
+
+
+## How to Build for EODHP
+
+Need to use the Dockerfile in the `docker/dru` directory. So run the following command: `docker build -f docker/dru/Dockerfile -t zoo-project:eodhp-<version-number> .` Then tag and send to ECR.

--- a/docker/dru/Dockerfile
+++ b/docker/dru/Dockerfile
@@ -170,7 +170,7 @@ RUN mkdir /tmp/cookiecutter-templates && \
     #pip install GDAL==3.4.3 && \
     pip install -r /tmp/requirements.txt && \
     cd /tmp && \
-    git clone https://github.com/Terradue/pycalrissian.git && \
+    git clone https://github.com/UKEODHP/pycalrissian.git && \
     cd pycalrissian && \
     sed "s:V1Subject:RbacV1Subject:g" -i pycalrissian/context.py && \
     python3 setup.py install && \


### PR DESCRIPTION
## Update to use EODHP-specific Pycalrissian
- We have now merged the latest ZOO-Project code into our fork branch
- Need to make sure our build still uses the EODHP pycalrissian fork so that our changes are included in the ZOO-Project images