### PR TITLE
Bump zoo-calrissian-runner to be EODHP specific

### DIFF
--- a/docker/dru/requirements.txt
+++ b/docker/dru/requirements.txt
@@ -4,7 +4,7 @@
  boto3
  kubernetes
  coverage
- git+https://github.com/EOEPCA/zoo-calrissian-runner.git@feature/access-log-status-failed
+ git+https://github.com/UKEODHP/zoo-calrissian-runner.git@main
  cheetah3
  psycopg2-binary
  pyyaml


### PR DESCRIPTION
Bump requirements to use EODHP specific `zoo-calrissian-runner`. This should address issues with workspace service accounts not being assigned to runner pods.
