### PR TITLE
Update cwlwrapper to use current EOEPCA build

### DIFF
--- a/docker/dru/Dockerfile
+++ b/docker/dru/Dockerfile
@@ -175,7 +175,7 @@ RUN mkdir /tmp/cookiecutter-templates && \
     sed "s:V1Subject:RbacV1Subject:g" -i pycalrissian/context.py && \
     python3 setup.py install && \
     cd .. && \
-    git clone https://github.com/UKEODHP/cwl-wrapper.git && \
+    git clone https://github.com/EOEPCA/cwl-wrapper.git && \
     cd cwl-wrapper/ && \
     python3 setup.py install && \
     cd .. && \


### PR DESCRIPTION
## Update Dockerfile
- As we now use AWS Credentials as inputs from the EODHP API, we can remove any need to generate these credentials within the stagein step
- Therefore, we can remove any code that previously force the stagein to be run for each execution
- This was handled by the `cwlwrapper` so we can use the previous repository from EOEPCA instead